### PR TITLE
Added onTouchStart handler to listeners

### DIFF
--- a/easypz.ts
+++ b/easypz.ts
@@ -281,6 +281,7 @@ class EasyPZ
     private listeners = {
         'mousedown': this.onMouseDown.bind(this),
         'mousemove': this.onMouseMove.bind(this),
+        'touchstart': this.onTouchStart.bind(this),
         'touchmove': this.onTouchMove.bind(this),
         'mouseup': this.onMouseUp.bind(this),
         'mouseout': this.onMouseOut.bind(this),


### PR DESCRIPTION
Doing my research i found that library works on easypz.io for mobile devices only because of polyfills. Not the case with my app so nothing was listening for touchstart event.